### PR TITLE
Fix handling of '-' token in BRDA lines.

### DIFF
--- a/test/expected/basic/lcov.info
+++ b/test/expected/basic/lcov.info
@@ -21,4 +21,5 @@ DA:34,18
 DA:37,2
 BRDA:24,1,0,2
 BRDA:24,1,1,16
+BRDA:24,1,2,-
 end_of_record

--- a/test/fixtures/basic/a/lcov.info
+++ b/test/fixtures/basic/a/lcov.info
@@ -45,8 +45,9 @@ DA:34,9
 DA:37,1
 LF:17
 LH:17
-BRDA:24,1,0,1
+BRDA:24,1,0,-
 BRDA:24,1,1,8
+BRDA:24,1,2,-
 BRF:2
 BRH:2
 end_of_record

--- a/test/fixtures/basic/b/lcov.info
+++ b/test/fixtures/basic/b/lcov.info
@@ -45,8 +45,9 @@ DA:34,9
 DA:37,1
 LF:17
 LH:17
-BRDA:24,1,0,1
+BRDA:24,1,0,2
 BRDA:24,1,1,8
+BRDA:24,1,2,-
 BRF:2
 BRH:2
 end_of_record


### PR DESCRIPTION
The LCov spec says that '-' is a valid fourth token where the
block containing the branch was never executed and as such, the
branch could never have been taken. This is subtly different from
'branch never taken'.

lcov-result-merger did not handle this case (it just treated it
as a number) and the result was that branch execution counts could
be 'NaN'.