### PR TITLE
Replace vinyl-fs with glob-stream

### DIFF
--- a/bin/lcov-result-merger.js
+++ b/bin/lcov-result-merger.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const vfs = require('vinyl-fs')
+var gs = require('glob-stream');
 const through = require('through2')
 const fs = require('fs')
 const lcovResultMerger = require('../index')
@@ -29,12 +29,13 @@ const args = yargs(hideBin(process.argv))
   })
   .argv
 
-vfs.src(args.pattern)
+gs(args.pattern)
   .pipe(lcovResultMerger(args))
   .pipe(through.obj((file) => {
+    const fileContentStr = fs.readSync(file, "utf8")
     if (args.outFile) {
-      fs.writeFileSync(args.outFile, file.contents)
+      fs.writeFileSync(args.outFile, fileContentStr)
     } else {
-      process.stdout.write(file.contents)
+      process.stdout.write(fileContentStr)
     }
   }))

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "through2": "^2.0.3",
-    "vinyl": "^2.1.0",
-    "vinyl-fs": "^3.0.2",
+    "glob-stream": "^7.0.0",
     "yargs": "^16.2.0"
   },
   "devDependencies": {
@@ -62,7 +61,7 @@
     "travis-deploy-once": "^5.0.0"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=10"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
Vinyl-fs didn't have any updates since a few years ago and the version of glob-parent they use has vulnerabilities reported by DependaBot. So I'd like to propose replacing it with [glob-stream](https://www.npmjs.com/package/glob-stream) directly.