### PR TITLE
Bugfix/lcov input file ordering

### DIFF
--- a/bin/lcov-result-merger.js
+++ b/bin/lcov-result-merger.js
@@ -35,7 +35,7 @@ const args = yargs(hideBin(process.argv))
   })
   .argv
 
-fg.stream(args.pattern)
+fg.stream(args.pattern, { absolute: true })
   .pipe(lcovResultMerger(args))
   .pipe(through.obj((filePath) => {
     const file = fs.openSync(filePath, "r+")

--- a/index.js
+++ b/index.js
@@ -329,9 +329,14 @@ function processFile (sourceDir, data, lcov, config) {
  * @returns {string}
  */
 function createRecords (coverageFiles) {
-  return coverageFiles.map(function (coverageFile) {
-    return coverageFile.toString()
-  }).join('')
+  return coverageFiles
+    .sort(function (fileA, fileB) {
+      return fileA.filename.localeCompare(fileB.filename)
+    })
+    .map(function (coverageFile) {
+      return coverageFile.toString()
+    })
+    .join('')
 }
 
 module.exports = function (config) {

--- a/test/expected/basic/lcov.info
+++ b/test/expected/basic/lcov.info
@@ -1,6 +1,3 @@
-SF:./src/index.js
-DA:1,2
-end_of_record
 SF:./src/Foo.js
 DA:1,2
 DA:4,2
@@ -22,4 +19,7 @@ DA:37,2
 BRDA:24,1,0,2
 BRDA:24,1,1,16
 BRDA:24,1,2,-
+end_of_record
+SF:./src/index.js
+DA:1,2
 end_of_record

--- a/test/expected/prepended-path-fix/lcov.info
+++ b/test/expected/prepended-path-fix/lcov.info
@@ -1,6 +1,3 @@
-SF:./test/fixtures/coverage-subfolder/a/src/index.js
-DA:1,1
-end_of_record
 SF:./test/fixtures/coverage-subfolder/a/src/Foo.js
 DA:1,1
 DA:4,1
@@ -23,7 +20,7 @@ BRDA:24,1,0,-
 BRDA:24,1,1,8
 BRDA:24,1,2,-
 end_of_record
-SF:./test/fixtures/coverage-subfolder/b/src/index.js
+SF:./test/fixtures/coverage-subfolder/a/src/index.js
 DA:1,1
 end_of_record
 SF:./test/fixtures/coverage-subfolder/b/src/Foo.js
@@ -47,4 +44,7 @@ DA:37,1
 BRDA:24,1,0,2
 BRDA:24,1,1,8
 BRDA:24,1,2,-
+end_of_record
+SF:./test/fixtures/coverage-subfolder/b/src/index.js
+DA:1,1
 end_of_record

--- a/test/expected/prepended/lcov.info
+++ b/test/expected/prepended/lcov.info
@@ -1,6 +1,3 @@
-SF:./test/fixtures/basic/a/src/index.js
-DA:1,1
-end_of_record
 SF:./test/fixtures/basic/a/src/Foo.js
 DA:1,1
 DA:4,1
@@ -23,7 +20,7 @@ BRDA:24,1,0,-
 BRDA:24,1,1,8
 BRDA:24,1,2,-
 end_of_record
-SF:./test/fixtures/basic/b/src/index.js
+SF:./test/fixtures/basic/a/src/index.js
 DA:1,1
 end_of_record
 SF:./test/fixtures/basic/b/src/Foo.js
@@ -47,4 +44,7 @@ DA:37,1
 BRDA:24,1,0,2
 BRDA:24,1,1,8
 BRDA:24,1,2,-
+end_of_record
+SF:./test/fixtures/basic/b/src/index.js
+DA:1,1
 end_of_record


### PR DESCRIPTION
Provide a guarantee of consistent merged output by sorting against the filenames of each source before merging into a final result.

This is a forth solution to the ones outlined in https://github.com/mweibel/lcov-result-merger/issues/51#issuecomment-1322553643