### PR TITLE
fix: remove lcov.info in ./ after processing

### DIFF
--- a/bin/lcov-result-merger.js
+++ b/bin/lcov-result-merger.js
@@ -43,13 +43,16 @@ fg.stream(args.pattern, { absolute: true })
   .pipe(lcovResultMerger(args))
   .pipe(
     through.obj((filePath) => {
-      const file = fs.openSync(filePath, 'r+');
-      const fileContentStr = fs.readFileSync(file, 'utf8');
+      const fileContentStr = fs.readFileSync(filePath, {
+        encoding: 'utf-8',
+        flag: 'r+'
+      });
+      fs.unlinkSync(filePath);
+
       if (args.outFile) {
         fs.writeFileSync(args.outFile, fileContentStr);
       } else {
         process.stdout.write(fileContentStr);
       }
-      fs.closeSync(file);
     })
   );

--- a/index.js
+++ b/index.js
@@ -368,20 +368,23 @@ module.exports = function (config) {
         callback();
         return;
       }
-      const file = fs.openSync(filePath, 'r');
-      const fileContentStr = fs.readFileSync(file, 'utf8');
+      const fileContentStr = fs.readFileSync(filePath, {
+        encoding: 'utf8',
+        flag: 'r'
+      });
       coverageFiles = processFile(
         path.dirname(filePath),
         fileContentStr,
         coverageFiles,
         config || {}
       );
-      fs.closeSync(file);
       callback();
     },
     function flush() {
-      const file = fs.openSync('lcov.info', 'w+');
-      fs.writeFileSync(file, Buffer.from(createRecords(coverageFiles)));
+      fs.writeFileSync('lcov.info', Buffer.from(createRecords(coverageFiles)), {
+        encoding: 'utf-8',
+        flag: 'w+'
+      });
       this.push('lcov.info');
       this.emit('end');
     }


### PR DESCRIPTION
When running the CLI, with an outPath or not a file named lcov.info is always created.

This fix remove the tmp file created at the end of the CLI process

+ refactor: replace `fs.openSync`/`fs.closeSync` but using options object on `readFileSync`/`writeFileSync`